### PR TITLE
fix download permissions error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ext/blackbone"]
 	path = ext/blackbone
-	url = git@github.com:coffeegrind123/Blackbone.git
+	url = https://github.com/coffeegrind123/Blackbone.git
 	branch = master


### PR DESCRIPTION
Fixes error with Amalgam-Comp's setup.bat
```
Cloning into 'G:/Amalgam-Comp/AmalgamLoader/ext/blackbone'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:coffeegrind123/Blackbone.git' into submodule path 'G:/Amalgam-Comp/AmalgamLoader/ext/blackbone' failed
Failed to clone 'ext/blackbone'. Retry scheduled
```